### PR TITLE
Add sqlserver support for debezium source

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/DebeziumConstants.java
@@ -48,6 +48,11 @@ public class DebeziumConstants {
   public static final String INCOMING_SOURCE_LSN_FIELD = "source.lsn";
   public static final String INCOMING_SOURCE_XMIN_FIELD = "source.xmin";
 
+  // INPUT COLUMNS SPECIFIC TO SQLSERVER
+  public static final String INCOMING_SOURCE_CHANGE_LSN_FIELD = "source.change_lsn";
+  public static final String INCOMING_SOURCE_COMMIT_LSN_FIELD = "source.commit_lsn";
+  public static final String INCOMING_SOURCE_EVENT_SERIAL_NO_FIELD = "source.event_serial_no";
+
   // OUTPUT COLUMNS
   public static final String FLATTENED_OP_COL_NAME = "_change_operation_type";
   public static final String UPSTREAM_PROCESSING_TS_COL_NAME = "_upstream_event_processed_ts_ms";
@@ -65,6 +70,11 @@ public class DebeziumConstants {
   // OUTPUT COLUMNS SPECIFIC TO POSTGRES
   public static final String FLATTENED_LSN_COL_NAME = "_event_lsn";
   public static final String FLATTENED_XMIN_COL_NAME = "_event_xmin";
+
+  // OUTPUT COLUMNS SPECIFIC TO SQLSERVER
+  public static final String FLATTENED_CHANGE_LSN_COL_NAME = "_event_xmin";
+  public static final String FLATTENED_COMMIT_LSN_COL_NAME = "_event_commit_lsn";
+  public static final String FLATTENED_EVENT_SERIAL_NO_COL_NAME = "_event_event_serial_no";
 
   // Other Constants
   public static final String DELETE_OP = "d";

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/SqlserverDebeziumAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/debezium/SqlserverDebeziumAvroPayload.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model.debezium;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieDebeziumAvroPayloadException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Provides support for seamlessly applying changes captured via Debezium for SQLServer DB.
+ * <p>
+ * Debezium change event types are determined for the op field in the payload
+ * <p>
+ * - For inserts, op=i
+ * - For deletes, op=d
+ * - For updates, op=u
+ * - For snapshot inserts, op=r
+ * <p>
+ * This payload implementation will issue matching insert, delete, updates against the hudi table
+ */
+public class SqlserverDebeziumAvroPayload extends AbstractDebeziumAvroPayload {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SqlserverDebeziumAvroPayload.class);
+
+  public SqlserverDebeziumAvroPayload(GenericRecord record, Comparable orderingVal) {
+    super(record, orderingVal);
+  }
+
+  public SqlserverDebeziumAvroPayload(Option<GenericRecord> record) {
+    super(record);
+  }
+
+  private Option<String> extractLSN(IndexedRecord record) {
+    Object value = ((GenericRecord) record).get(DebeziumConstants.FLATTENED_CHANGE_LSN_COL_NAME);
+    return Option.ofNullable(Objects.toString(value, null));
+  }
+
+  @Override
+  protected boolean shouldPickCurrentRecord(IndexedRecord currentRecord, IndexedRecord insertRecord, Schema schema) throws IOException {
+    String insertSourceChangeLSN = extractLSN(insertRecord)
+        .orElseThrow(() ->
+            new HoodieDebeziumAvroPayloadException(String.format("%s cannot be null in insert record: %s",
+                DebeziumConstants.FLATTENED_CHANGE_LSN_COL_NAME, insertRecord)));
+    Option<String> currentSourceChangeLSN = extractLSN(currentRecord);
+
+    return currentSourceChangeLSN.isPresent() && insertSourceChangeLSN.compareTo(currentSourceChangeLSN.get()) < 0;
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/SqlserverDebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/SqlserverDebeziumSource.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.sources.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.utilities.ingestion.HoodieIngestionMetrics;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Source for incrementally ingesting debezium generated change logs for SQLServer DB.
+ */
+public class SqlserverDebeziumSource extends DebeziumSource {
+  public SqlserverDebeziumSource(TypedProperties props, JavaSparkContext sparkContext,
+                                 SparkSession sparkSession,
+                                 SchemaProvider schemaProvider,
+                                 HoodieIngestionMetrics metrics) {
+    super(props, sparkContext, sparkSession, schemaProvider, metrics);
+  }
+
+  /**
+   * Debezium Kafka Payload has a nested structure (see https://debezium.io/documentation/reference/2.2/connectors/sqlserver.html#sqlserver-create-events).
+   * This function flattens this nested structure for the SQLServer data, and also extracts a subset of Debezium metadata fields.
+   *
+   * @param rowDataset Dataset containing Debezium Payloads
+   * @return New dataset with flattened columns
+   */
+  @Override
+  protected Dataset<Row> processDataset(Dataset<Row> rowDataset) {
+    if (rowDataset.columns().length > 0) {
+      // Pick selective debezium and sqlserver meta fields: pick the row values from before field for delete record
+      // and row values from after field for insert or update records.
+      Dataset<Row> insertedOrUpdatedData = rowDataset
+          .selectExpr(
+              String.format("%s as %s", DebeziumConstants.INCOMING_OP_FIELD, DebeziumConstants.FLATTENED_OP_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_TS_MS_FIELD, DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_NAME_FIELD, DebeziumConstants.FLATTENED_SHARD_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_SCHEMA_FIELD, DebeziumConstants.FLATTENED_SCHEMA_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_TS_MS_FIELD, DebeziumConstants.FLATTENED_TS_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_CHANGE_LSN_FIELD, DebeziumConstants.FLATTENED_CHANGE_LSN_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_COMMIT_LSN_FIELD, DebeziumConstants.FLATTENED_COMMIT_LSN_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_EVENT_SERIAL_NO_FIELD, DebeziumConstants.FLATTENED_EVENT_SERIAL_NO_COL_NAME),
+              String.format("%s.*", DebeziumConstants.INCOMING_AFTER_FIELD)
+          )
+          .filter(rowDataset.col(DebeziumConstants.INCOMING_OP_FIELD).notEqual(DebeziumConstants.DELETE_OP));
+
+      Dataset<Row> deletedData = rowDataset
+          .selectExpr(
+              String.format("%s as %s", DebeziumConstants.INCOMING_OP_FIELD, DebeziumConstants.FLATTENED_OP_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_TS_MS_FIELD, DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_NAME_FIELD, DebeziumConstants.FLATTENED_SHARD_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_SCHEMA_FIELD, DebeziumConstants.FLATTENED_SCHEMA_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_TS_MS_FIELD, DebeziumConstants.FLATTENED_TS_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_CHANGE_LSN_FIELD, DebeziumConstants.FLATTENED_CHANGE_LSN_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_COMMIT_LSN_FIELD, DebeziumConstants.FLATTENED_COMMIT_LSN_COL_NAME),
+              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_EVENT_SERIAL_NO_FIELD, DebeziumConstants.FLATTENED_EVENT_SERIAL_NO_COL_NAME),
+              String.format("%s.*", DebeziumConstants.INCOMING_BEFORE_FIELD)
+          )
+          .filter(rowDataset.col(DebeziumConstants.INCOMING_OP_FIELD).equalTo(DebeziumConstants.DELETE_OP));
+
+      return insertedOrUpdatedData.union(deletedData);
+    } else {
+      return rowDataset;
+    }
+  }
+}


### PR DESCRIPTION
### Change Logs

Support SQLServer as the data source for data ingestion.

### Impact

Won't impact the existed features.

### Risk level (write none, low medium or high below)

Risk level in low since it only effects someone use new feature.

### Documentation Update

- Support SQLServer as the data source.

### Contributor's checklist

- [✅] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [✅] Change Logs and Impact were stated clearly
- [✅ Adequate tests were added if applicable
- [❌] CI passed
