### PR TITLE
Skip transformer when no new data

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformer.java
@@ -57,6 +57,10 @@ public class SqlQueryBasedTransformer implements Transformer {
       throw new IllegalArgumentException("Missing configuration : (" + Config.TRANSFORMER_SQL + ")");
     }
 
+    if (rowDataset.isEmpty()) {
+      return rowDataset;
+    }
+
     // tmp table name doesn't like dashes
     String tmpTable = TMP_TABLE.concat(UUID.randomUUID().toString().replace("-", "_"));
     LOG.info("Registering tmp table : " + tmpTable);


### PR DESCRIPTION
### Change Logs

SQLBase

### Impact

`SqlQueryBasedTransformer.java` will transform data by SparkSQL, and when there is no data exists, SparkSQL will respond the no found column error.

### Risk level (write none, low medium or high below)

Risk level in medium because it might need empty data.

### Documentation Update

- Fix `SqlQueryBasedTransformer.java` column not found error when no new data exists.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [ ] CI passed
