### PR TITLE
fix: avoid autodetector determine serialno as string

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/SqlserverDebeziumJSONSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/SqlserverDebeziumJSONSource.java
@@ -62,7 +62,7 @@ public class SqlserverDebeziumJSONSource extends DebeziumJSONSource {
               String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_TS_MS_FIELD, DebeziumConstants.FLATTENED_TS_COL_NAME),
               String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_CHANGE_LSN_FIELD, DebeziumConstants.FLATTENED_CHANGE_LSN_COL_NAME),
               String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_COMMIT_LSN_FIELD, DebeziumConstants.FLATTENED_COMMIT_LSN_COL_NAME),
-              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_EVENT_SERIAL_NO_FIELD, DebeziumConstants.FLATTENED_EVENT_SERIAL_NO_COL_NAME),
+              String.format("CAST(%s AS LONG) AS %s", DebeziumConstants.INCOMING_SOURCE_EVENT_SERIAL_NO_FIELD, DebeziumConstants.FLATTENED_EVENT_SERIAL_NO_COL_NAME),
               String.format("%s.*", DebeziumConstants.INCOMING_AFTER_FIELD)
           )
           .filter(rowDataset.col(DebeziumConstants.INCOMING_OP_FIELD).notEqual(DebeziumConstants.DELETE_OP));
@@ -76,7 +76,7 @@ public class SqlserverDebeziumJSONSource extends DebeziumJSONSource {
               String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_TS_MS_FIELD, DebeziumConstants.FLATTENED_TS_COL_NAME),
               String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_CHANGE_LSN_FIELD, DebeziumConstants.FLATTENED_CHANGE_LSN_COL_NAME),
               String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_COMMIT_LSN_FIELD, DebeziumConstants.FLATTENED_COMMIT_LSN_COL_NAME),
-              String.format("%s as %s", DebeziumConstants.INCOMING_SOURCE_EVENT_SERIAL_NO_FIELD, DebeziumConstants.FLATTENED_EVENT_SERIAL_NO_COL_NAME),
+              String.format("CAST(%s AS LONG) AS %s", DebeziumConstants.INCOMING_SOURCE_EVENT_SERIAL_NO_FIELD, DebeziumConstants.FLATTENED_EVENT_SERIAL_NO_COL_NAME),
               String.format("%s.*", DebeziumConstants.INCOMING_BEFORE_FIELD)
           )
           .filter(rowDataset.col(DebeziumConstants.INCOMING_OP_FIELD).equalTo(DebeziumConstants.DELETE_OP));


### PR DESCRIPTION
### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
